### PR TITLE
Add IBM Cloud Spring Boot Service Bind dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.ibm.cloud</groupId>
+            <artifactId>ibm-cloud-spring-boot-service-bind</artifactId>
+            <version>1.1.2</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
To keep things consistent with other app repos where we include IBM Cloud Env out of the box.