### PR TITLE
Prepare Dockerfile  for multi stage builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,12 @@ RUN mvn -N io.takari:maven:wrapper -Dmaven=3.5.0
 COPY . /app
 RUN ./mvnw install
 
+ARG bx_dev_user=root
+ARG bx_dev_userid=1000
+RUN BX_DEV_USER=$bx_dev_user
+RUN BX_DEV_USERID=$bx_dev_userid
+RUN if [ $bx_dev_user != "root" ]; then useradd -ms /bin/bash -u $bx_dev_userid $bx_dev_user; fi
+
 # Multi-stage build. New build stage that uses the UBI as the base image.
 
 # In the short term, we are using the OpenJDK for UBI. Long term, we will use


### PR DESCRIPTION
This allows dev plugin to build this Dockerfile instead of dockerfile-tools. Current cli version will ignore these new lines.