### PR TITLE
Adding JaCoCo Plugin to build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,24 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Description:

This is to enable the project to leverage the JaCoCo plugin to run the code coverage in Test Mode.

---
Testing Done:

1. Ran unit test using command:

**Command**
```
mvn test
```

**Output**
```
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.6:report (report) @ javaspringapp ---
[INFO] Loading execution data file /home/piyush/java-spring-app/target/jacoco.exec
[INFO] Analyzed bundle 'javaspringapp' with 3 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 23.554 s
[INFO] Finished at: 2021-03-16T15:38:21Z
[INFO] ------------------------------------------------------------------------
```

<img width="1564" alt="image" src="https://user-images.githubusercontent.com/80688956/111338862-4aed8680-869d-11eb-8a9e-e401b274fd5b.png">
